### PR TITLE
Changes to environment data to allow for Insomnia nested variables

### DIFF
--- a/src/Models/Environment.cs
+++ b/src/Models/Environment.cs
@@ -4,6 +4,6 @@ namespace Insomnia.NET.Models
 {
     public class Environment : BaseResource
     {
-        public Dictionary<string, string> Data { get; set; }
+        public Dictionary<string, object> Data { get; set; }
     }
 }


### PR DESCRIPTION
Insomnia supports the ability to have nested variables which when exported in their JSON format is an object. 

The current implementation of string/string key-value pairs currently causes an exception to be thrown when deserializing in the Insomnia converter of Nightingale Core.  